### PR TITLE
Fix 'Undefined variable $pagin' warning

### DIFF
--- a/includes/core/frontend/Get_Posts.php
+++ b/includes/core/frontend/Get_Posts.php
@@ -448,7 +448,7 @@ class Get_Posts {
 			'max_num_pages' => $query->max_num_pages,
 			'post_count' => $query->post_count,
 			'get_current_posts' => ($query->found_posts - $paged * $per_page),
-			'pagin' => $pagin,
+			'pagin' => !empty($pagin) ? $pagin : null,
 			'paged' => $paged
 		];
 


### PR DESCRIPTION
Fixes the PHP Warning in `debug.log` when hide pagination option is checked: 
`PHP Warning:  Undefined variable $pagin in ymc-smart-filter\includes\core\frontend\Get_Posts.php on line 451`