### PR TITLE
Fix Strings translation in advanced.php

### DIFF
--- a/includes/core/admin/tabs/advanced.php
+++ b/includes/core/admin/tabs/advanced.php
@@ -1062,7 +1062,7 @@
                         echo '<option value="preloader_'.$i.'" '. $selected_preloader .'>'. esc_html__('None', 'ymc-smart-filter') .'</option>';
                     }
                     else {
-                        echo '<option value="preloader_'.$i.'" '. $selected_preloader .'>'. esc_html__('Preloader '.$i, 'ymc-smart-filter') .'</option>';
+                        echo '<option value="preloader_'.$i.'" '. $selected_preloader .'>'. esc_html__('Preloader ', 'ymc-smart-filter') .$i .'</option>';
                     }
                     $selected_preloader = '';
                 }


### PR DESCRIPTION
Fix Strings translation in advanced.php

Hello @YMC-22

The variable **$i** must be placed **after** the function that translates the string, otherwise the translation does not work.

Thanks.

**Before**:

![filter-before](https://github.com/user-attachments/assets/8593d19f-5055-48fd-b8f4-863eebef9e51)

**After**:

![filter-after](https://github.com/user-attachments/assets/961ee5ab-c971-4544-b222-6814bbefdaf6)
